### PR TITLE
sphinxcontrib-htmlhelp 2.1.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
   noarch: python
 
 requirements:
@@ -40,7 +40,7 @@ test:
     - python -m pytest -v tests
 
 about:
-  home: http://sphinx-doc.org/
+  home: https://sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENCE.rst

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ requirements:
     - pip
     - flit-core >=3.7
   run:
-    - python 3.9
-    - sphinx >=5
+    - python >=3.9
     
 test:
   source_files:
@@ -36,7 +35,7 @@ test:
     # This is a circular dependency b/c sphinx depends on this package now :-/
     - sphinx >=5
   commands:
-    - pip check
+    #- pip check
     - python -m pytest -v tests
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,29 @@
-{% set version = "2.0.0" %}
+{% set name = "sphinxcontrib-htmlhelp" %}
+{% set version = "2.1.0" %}
 
 package:
-  name: sphinxcontrib-htmlhelp
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-{{ version }}.tar.gz
-  sha256: f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2
+  url: https://pypi.org/packages/source/s/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-{{ version }}.tar.gz
+  sha256: c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9
 
 build:
   number: 0
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
+    - flit-core >=3.7
   run:
-    - python >=3.6
+    - python
+    - sphinx >=5
     
 test:
   source_files:
@@ -29,20 +32,20 @@ test:
     - sphinxcontrib
     - sphinxcontrib.htmlhelp
   requires:
-    #- pip
+    - pip
     - html5lib
     - pytest
     # This is a circular dependency b/c sphinx depends on this package now :-/
     - sphinx >=2
   commands:
-    #- pip check
-    - python -m pytest -v tests
+    - pip check
+    #- python -m pytest -v tests
 
 about:
   home: http://sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENCE.rst
   summary: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files.
   dev_url: https://github.com/sphinx-doc/sphinxcontrib-htmlhelp
   doc_url: https://www.sphinx-doc.org/en/master/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,17 +12,17 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: true  # [py<39]
+  noarch: python
 
 requirements:
   host:
-    - python
+    - python  >=3.9
     - pip
     - setuptools
     - wheel
     - flit-core >=3.7
   run:
-    - python
+    - python >=3.9
     - sphinx >=5
     
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
     - pytest
     # This is a circular dependency b/c sphinx depends on this package now :-/
     - sphinx >=5
+    - defusedxml
   commands:
     #- pip check
     - python -m pytest -v tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,11 @@ build:
 
 requirements:
   host:
-    - python  >=3.9
+    - python 3.9
     - pip
-    - setuptools
-    - wheel
     - flit-core >=3.7
   run:
-    - python >=3.9
+    - python 3.9
     - sphinx >=5
     
 test:
@@ -36,10 +34,10 @@ test:
     - html5lib
     - pytest
     # This is a circular dependency b/c sphinx depends on this package now :-/
-    - sphinx >=2
+    - sphinx >=5
   commands:
     - pip check
-    #- python -m pytest -v tests
+    - python -m pytest -v tests
 
 about:
   home: http://sphinx-doc.org/
@@ -47,6 +45,10 @@ about:
   license_family: BSD
   license_file: LICENCE.rst
   summary: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files.
+  description: |
+    This builder produces the same output as the standalone HTML builder, 
+    but also generates HTML Help support files that allow the Microsoft HTML
+    Help Workshop to compile them into a CHM file.
   dev_url: https://github.com/sphinx-doc/sphinxcontrib-htmlhelp
   doc_url: https://www.sphinx-doc.org/en/master/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/s/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9
 
 build:
@@ -36,7 +36,7 @@ test:
     - sphinx >=5
     - defusedxml
   commands:
-    #- pip check
+    - pip check
     - python -m pytest -v tests
 
 about:


### PR DESCRIPTION
sphinxcontrib-htmlhelp 2.1.0 

**Destination channel:** Defaults

### Links

- [PKG-7692]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-htmlhelp/tree/2.1.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-htmlhelp-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-htmlhelp/2.1.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-htmlhelp/2.1.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- new version number
- - keeping noarch due to test circular dependencies with sphinx


[PKG-7692]: https://anaconda.atlassian.net/browse/PKG-7692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ